### PR TITLE
Fix meta keywords typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=0.5">
       <title>Electromás | Electrodomésticos y Tecnología para el Hogar</title>
       <meta name="description" content="Encuentre los mejores electrodomésticos y tecnología para su hogar en Electromás. Descubra nuestras ofertas y combos exclusivos.">
-      <meta name="keywords" content="electrodomésticos, tecnología, hogar, ofertas, celulares, computadores, portatiles, electromas">
+      <meta name="keywords" content="electrodomésticos, tecnología, hogar, ofertas, celulares, computadores, portátiles, electromas">
       <meta name="author" content="Electromás">
       <link rel="shortcut icon" href="principal/general/logo.png" type="image/png">
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">


### PR DESCRIPTION
## Summary
- correct "portátiles" spelling in meta keywords

## Testing
- `tidy -errors index.html` *(fails: command not found)*
- `html5validator index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846626872b0832ea71e0a6032eb026e